### PR TITLE
chore: Add release pipeline to PyPi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,21 @@ jobs:
 
       - name: Run pyright
         run: uv run pyright
+
+
+  deploy:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build and publish to PyPi
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          uv build
+          uv publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Core
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -44,6 +45,8 @@ jobs:
   deploy:
     needs: build-and-test
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    workflow_dispatch:
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-    workflow_dispatch:
-
     steps:
       - uses: actions/checkout@v4
 
@@ -57,6 +55,6 @@ jobs:
       - name: Build and publish to PyPi
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          uv build
-          uv publish
+          run: |
+            uv build
+            uv publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build and publish to PyPi
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          run: |
+            uv build
+            uv publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,20 +41,3 @@ jobs:
       - name: Run pyright
         run: uv run pyright
 
-
-  deploy:
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Build and publish to PyPi
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-          run: |
-            uv build
-            uv publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Core
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "openexchangerates"
+name = "oxr"
 version = "0.1.0"
 description = "Type-safe client for the openexchangerates API."
 authors = [{ name = "Maxwell Muoto", email = "maxmuoto@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,26 @@ readme = "README.md"
 dependencies = ["requests>=2.32.3,<3", "typing-extensions>=4.12.2,<5"]
 requires-python = ">=3.9"
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+packages = ["oxr"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["oxr"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"oxr/py.typed" = "oxr/py.typed"
+
+[tool.hatch.envs.async]
+dependencies = ["aiohttp>=3.9.5,<4.0.0"]
+
+[tool.hatch.build.targets.wheel.async]
+name = "oxr-async"
+dependencies = ["aiohttp>=3.9.5,<4.0.0"]
+
 [tool.coverage.run]
 source = ["oxr"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,21 +12,10 @@ requires-python = ">=3.9"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build]
-packages = ["oxr"]
 
-[tool.hatch.build.targets.wheel]
-packages = ["oxr"]
+[project.optional-dependencies]
+async = ["aiohttp>=3.9.5,<4"]
 
-[tool.hatch.build.targets.wheel.shared-data]
-"oxr/py.typed" = "oxr/py.typed"
-
-[tool.hatch.envs.async]
-dependencies = ["aiohttp>=3.9.5,<4.0.0"]
-
-[tool.hatch.build.targets.wheel.async]
-name = "oxr-async"
-dependencies = ["aiohttp>=3.9.5,<4.0.0"]
 
 [tool.coverage.run]
 source = ["oxr"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ build-backend = "hatchling.build"
 [project.optional-dependencies]
 async = ["aiohttp>=3.9.5,<4"]
 
-
 [tool.coverage.run]
 source = ["oxr"]
 


### PR DESCRIPTION
Add release pipeline, and an `async` variant to avoid including `aiohttp` in the main installation.